### PR TITLE
Fix build on unsupported OS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,16 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[cfg_attr(target_os = "windows", path = "windows.rs")]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), path = "linux.rs")]
-#[cfg_attr(any(target_os = "macos", target_os = "ios"), path = "darwin.rs")]
+#[cfg(target_os = "windows")]
+#[path = "windows.rs"]
+mod platform;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[path = "linux.rs"]
+mod platform;
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[path = "darwin.rs"]
 mod platform;
 
 #[cfg(not(any(
@@ -59,6 +66,8 @@ mod platform;
     target_os = "ios",
 )))]
 mod platform {
+    use crate::MemoryStats;
+
     pub fn memory_stats() -> Option<MemoryStats> {
         None
     }
@@ -91,16 +100,6 @@ pub struct MemoryStats {
 /// If the current memory usage cannot be queried
 /// or `memory_stats` is run on a unsupported platform,
 /// `None` is returned.
-#[cfg_attr(
-    not(any(
-        target_os = "windows",
-        target_os = "linux",
-        target_os = "android",
-        target_os = "macos",
-        target_os = "ios",
-    )),
-    deprecated("memory-stats doesn't support this platform!")
-)]
 pub fn memory_stats() -> Option<MemoryStats> {
     platform::memory_stats()
 }


### PR DESCRIPTION
  - `src/lib.rs`: replace conditional compilation with `cfg_attr` by `cfg` to define platform module + fix for unsupported OS
  - build/tests OK with an example code on Linux (OS supported) and OpenBSD (OS unsupported)

  - fix Arc-blroth/memory-stats#7